### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Initializes a new instance of the Validator class.
 
 <br/>
 
-**`validate(self, value, metadata={}) → ValidationResult`**
+**`validate(self, value, metadata={}) -> ValidationResult`**
 
 <ul>
 


### PR DESCRIPTION
Fix UnicodeEncodeError for the character '\u2192' in the 'guardrails hub install' console output.

Resolved an issue where the Unicode character '\u2192' (right arrow) caused a UnicodeEncodeError during guardrails installations on Windows, Linux, macOS