### PR TITLE
[bug] Pin numpy<2.0 until spacy supports it.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">= 3.8.1"
 dependencies = [
     "nltk",
     "spacy",
+    "numpy<2.0",  # When spacy starts to support numpy >= 2.0, we can remove this pin.
     "guardrails-ai>=0.4.0"
 ]
 


### PR DESCRIPTION
The release of numpy 2.0 two days ago does not interact well with the spacy dependency.  Pin numpy < 2.0 until spacy supports it.