### PR TITLE
fix: warning for importing from validators directory

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Optional
 
 # from guardrails.validator_base import ErrorSpan
 from guardrails.logger import logger
-from guardrails.validators import (
+from guardrails.validator_base import (
     FailResult,
     PassResult,
     ValidationResult,


### PR DESCRIPTION
`CompetitorCheck` Validator was importing certain classes from `guardrails.validators` instead of `guardrails.validator_base` raising to an unnecessary warning.

```
    Importing validators from `guardrails.validators` is deprecated.
    All validators are now available in the Guardrails Hub. Please install
    and import them from the hub instead. All validators will be
    removed from this module in the next major release.

    Install with: `guardrails hub install hub://<namespace>/<validator_name>`
    Import as: from guardrails.hub import `ValidatorName`
```